### PR TITLE
support astropy 2 and 4

### DIFF
--- a/simqso/hiforest.py
+++ b/simqso/hiforest.py
@@ -26,7 +26,7 @@ def _getlinelistdata():
     # https://svn.ucolick.org/xidl/trunk/Spec/Lines/all_lin.fits
     linelist = fits.getdata(os.path.join(datadir,'all_lin.fits'))
     Hlines = np.array([i for i in range(linelist.size) 
-                           if b'HI' in linelist.ION[i]])
+                           if 'HI' in linelist['ION'][i]])
     transitionParams = {}
     for n,idx in enumerate(Hlines[::-1],start=2):
         transitionParams[n] = (linelist.WREST[idx],


### PR DESCRIPTION
This PR makes a small update to support astropy 4.x, while still retaining compatibility with astropy 2.x.  The current version of simqso + astropy 4.x crashes upon import:
```
In [1]: import simqso                                                           
...
/global/common/software/desi/users/sjbailey/simqso/simqso/hiforest.py in <listcomp>(.0)
     27     linelist = fits.getdata(os.path.join(datadir,'all_lin.fits'))
     28     Hlines = np.array([i for i in range(linelist.size) 
---> 29                            if b'HI' in linelist.ION[i]])
     30     transitionParams = {}
     31     for n,idx in enumerate(Hlines[::-1],start=2):

TypeError: 'in <string>' requires string as left operand, not bytes
```

@imcgreer after reviewing and merging this PR, could you please make a new simqso tag so that we can use it in our next DESI software release?  Thanks.

### Background ###

In astropy 2.x, `linelist.ION` is a `numpy.ndarray` object and `linelist.ION[0]` is `numpy.bytes_` thus requiring code like the current `if b'HI' in linelist.ION[i]`.  But inconsistently, `linelist['ION']` is a `numpy.chararray` and `linelist['ION'][0]` is a `str` requiring comparisons like `if 'HI' in linelist.ION[i]` instead (note `'HI'` str not `b'HI'` bytes).

astropy 4.x (or maybe 3.x) made these consistent with both `linelist.ION` and `linelist['ION']` being `numpy.chararray` objects with individual elements that are `str`, thus breaking the previous comparison with `b'HI'`.  The syntax that works with both astropy 2.x and 4.x is:
```
if 'HI' in linelist['ION'][i]]
```